### PR TITLE
Add custom nav bar for Qermit docs

### DIFF
--- a/docs_src/_static/custom.css
+++ b/docs_src/_static/custom.css
@@ -35,3 +35,22 @@ html[data-theme=light] {
 .sig-name {
     font-size: 1.25rem;
 }
+
+.navbar .navbar-brand img {
+    height: 100%;
+    max-width: 100%;
+    width: auto;
+}
+
+.navbar .navbar-brand {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: .5rem;
+    height: var(--pst-header-height);
+    margin: 0;
+    max-height: var(--pst-header-height);
+    padding: .5rem 0;
+    position: relative;
+    width: auto;
+}

--- a/docs_src/_templates/navbar-nav.html
+++ b/docs_src/_templates/navbar-nav.html
@@ -1,0 +1,16 @@
+{# Displays links to the top-level TOCtree elements, in the header navbar. #}
+<nav class="navbar-nav">
+  <ul class="bd-navbar-elements navbar-nav">
+    {# generate_fixed_header_nav_html() #}
+    <li class="nav-item pst-header-nav-item">
+      <a class="nav-link nav-internal" href="https://cqcl.github.io/quantinuum-docs/qermit/index.html">
+        API reference
+      </a>
+    </li>
+        <li class="nav-item pst-header-nav-item">
+      <a class="nav-link nav-internal" href="https://cqcl.github.io/quantinuum-docs/qermit/manual/index.html">
+        User manual
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/docs_src/_templates/navbar-root-logo.html
+++ b/docs_src/_templates/navbar-root-logo.html
@@ -1,0 +1,24 @@
+{# Displays the logo of your documentation site, in the header navbar. #}
+
+{#- Logo HTML and image #}
+<a class="navbar-brand logo" href="https://cqcl.github.io/quantinuum-docs/index.html">
+  {# get all the brand information from html_theme_option #}
+  {% set is_logo = "light" in theme_logo["image_relative"] %}
+  {# use alt_text if given. If not, only add alt text if no additional branding text given. #}
+  {% set alt = theme_logo.get("alt_text", "" if theme_logo.get("text") else "%s - Home" % docstitle) %}
+  {% if is_logo %}
+    {# Theme switching is only available when JavaScript is enabled.
+     # Thus we should add the extra image using JavaScript, defaulting
+     # depending on the value of default_mode; and light if unset.
+     #}
+    {% if default_mode is undefined or default_mode == "auto" %}
+      {% set default_mode = "light" %}
+    {% endif %}
+    {% set js_mode = "light" if default_mode == "dark" else "dark" %}
+    <img src="{{ theme_logo['image_relative'][default_mode] }}" class="logo__image only-{{ default_mode }}" alt="{{ alt }}"/>
+    <script>document.write(`<img src="{{ theme_logo['image_relative'][js_mode] }}" class="logo__image only-{{ js_mode }}" alt="{{ alt }}"/>`);</script>
+  {% endif %}
+  {% if not is_logo or theme_logo.get("text") %}
+    <p class="title logo__title">{{ theme_logo.get("text") or docstitle }}</p>
+  {% endif %}
+</a>

--- a/docs_src/unified_docs_conf.py
+++ b/docs_src/unified_docs_conf.py
@@ -76,6 +76,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
+    "header_manual_links": [
+        { "url": "https://cqcl.github.io/quantinuum-docs/qermit/index.html", "name": "API reference"},
+        { "url": "https://cqcl.github.io/quantinuum-docs/qermit/manual/index.html", "name": "User manual"},
+    ],
     "header_links_before_dropdown": 1,
     "logo": {
         "image_light": "_static/Quantinuum_logo_black.png",

--- a/docs_src/unified_docs_conf.py
+++ b/docs_src/unified_docs_conf.py
@@ -73,13 +73,11 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pydata_sphinx_theme"
+html_theme = "sphinx_book_theme"
 
 html_theme_options = {
-    "header_manual_links": [
-        { "url": "https://cqcl.github.io/quantinuum-docs/qermit/index.html", "name": "API reference"},
-        { "url": "https://cqcl.github.io/quantinuum-docs/qermit/manual/index.html", "name": "User manual"},
-    ],
+    "navbar_start": ["navbar-root-logo"],
+    "navbar_center": ["navbar-nav"],
     "header_links_before_dropdown": 1,
     "logo": {
         "image_light": "_static/Quantinuum_logo_black.png",

--- a/manual/_static/custom.css
+++ b/manual/_static/custom.css
@@ -35,3 +35,22 @@ html[data-theme=light] {
 .sig-name {
     font-size: 1.25rem;
 }
+
+.navbar .navbar-brand img {
+    height: 100%;
+    max-width: 100%;
+    width: auto;
+}
+
+.navbar .navbar-brand {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: .5rem;
+    height: var(--pst-header-height);
+    margin: 0;
+    max-height: var(--pst-header-height);
+    padding: .5rem 0;
+    position: relative;
+    width: auto;
+}

--- a/manual/_templates/navbar-nav.html
+++ b/manual/_templates/navbar-nav.html
@@ -1,0 +1,16 @@
+{# Displays links to the top-level TOCtree elements, in the header navbar. #}
+<nav class="navbar-nav">
+  <ul class="bd-navbar-elements navbar-nav">
+    {# generate_fixed_header_nav_html() #}
+    <li class="nav-item pst-header-nav-item">
+      <a class="nav-link nav-internal" href="https://cqcl.github.io/quantinuum-docs/qermit/index.html">
+        API reference
+      </a>
+    </li>
+        <li class="nav-item pst-header-nav-item">
+      <a class="nav-link nav-internal" href="https://cqcl.github.io/quantinuum-docs/qermit/manual/index.html">
+        User manual
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/manual/_templates/navbar-root-logo.html
+++ b/manual/_templates/navbar-root-logo.html
@@ -1,0 +1,24 @@
+{# Displays the logo of your documentation site, in the header navbar. #}
+
+{#- Logo HTML and image #}
+<a class="navbar-brand logo" href="https://cqcl.github.io/quantinuum-docs/index.html">
+  {# get all the brand information from html_theme_option #}
+  {% set is_logo = "light" in theme_logo["image_relative"] %}
+  {# use alt_text if given. If not, only add alt text if no additional branding text given. #}
+  {% set alt = theme_logo.get("alt_text", "" if theme_logo.get("text") else "%s - Home" % docstitle) %}
+  {% if is_logo %}
+    {# Theme switching is only available when JavaScript is enabled.
+     # Thus we should add the extra image using JavaScript, defaulting
+     # depending on the value of default_mode; and light if unset.
+     #}
+    {% if default_mode is undefined or default_mode == "auto" %}
+      {% set default_mode = "light" %}
+    {% endif %}
+    {% set js_mode = "light" if default_mode == "dark" else "dark" %}
+    <img src="{{ theme_logo['image_relative'][default_mode] }}" class="logo__image only-{{ default_mode }}" alt="{{ alt }}"/>
+    <script>document.write(`<img src="{{ theme_logo['image_relative'][js_mode] }}" class="logo__image only-{{ js_mode }}" alt="{{ alt }}"/>`);</script>
+  {% endif %}
+  {% if not is_logo or theme_logo.get("text") %}
+    <p class="title logo__title">{{ theme_logo.get("text") or docstitle }}</p>
+  {% endif %}
+</a>


### PR DESCRIPTION
This has a link back to the main docs site (cqcl.github.io/quantinuum-docs) and links to the API reference and user manual, so that it's possible to go between them.

It also uses sphinx-book-theme again to get the table of contents working in the left sidebar.

Ideally this would be in a Sphinx theme of its own, but this appears to work for now and getting a custom theme to work (when we're three levels down a theme inheritance chain) seems like it'll not be simple, so I'm going for this to start with.